### PR TITLE
Fixes for CoreDataMigrationManager

### DIFF
--- a/Sources/PubNubChat/Storage/CoreData/CoreDataMigrationManager.swift
+++ b/Sources/PubNubChat/Storage/CoreData/CoreDataMigrationManager.swift
@@ -34,58 +34,117 @@ import PubNub
 /// You don't have to provide a concrete implementation of `CoreDataMigrationManager` if you rely on `NSManagedObjectModel` provided in `chat-components-ios` bundle.
 /// Provide a concrete implementation when creating a `CoreDataProvider` object only if you use your custom model schema.
 public protocol CoreDataMigrationManager {
-  func migrateIfNeeded() throws
+  @discardableResult
+  func migrateIfNeeded() -> Bool
 }
 
 extension NSManagedObjectModel {
-  var versionID: Int {
+  var integerValue: Int {
     return Int(versionIdentifiers.first as? String ?? String()) ?? 0
   }
 }
 
 class DefaultCoreDataMigrationManager: CoreDataMigrationManager {
-  private let rootModel: NSManagedObjectModel
-  private let nextModelVersions: [NSManagedObjectModel]
+  
+  private let modelBundle: Bundle
+  private let modelURL: URL
   private let persistentStoreLocation: URL
   
   init(
-    rootModel: NSManagedObjectModel,
-    nextModelVersions: [NSManagedObjectModel],
+    modelBundle: Bundle,
+    modelURL: URL,
     persistentStoreLocation: URL
   ) {
-    self.rootModel = rootModel
-    self.nextModelVersions = nextModelVersions
+    self.modelBundle = modelBundle
+    self.modelURL = modelURL
     self.persistentStoreLocation = persistentStoreLocation
   }
   
-  func migrateIfNeeded() throws {
+  @discardableResult
+  func migrateIfNeeded() -> Bool {
+    
     guard FileManager.default.fileExists(atPath: persistentStoreLocation.relativePath) else {
-      return
+      PubNub.log.debug("NSPersistentStore at \(persistentStoreLocation.relativePath) doesn't exist. No need to migrate")
+      return false
     }
     
-    for modelVersion in nextModelVersions {
-      let storeMetadata = try NSPersistentStoreCoordinator.metadataForPersistentStore(
+    guard let currentPersistentStoreMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(
+      ofType: NSSQLiteStoreType,
+      at: persistentStoreLocation
+    ) else {
+      PubNub.log.error("Cannot get metadata from the currently used NSPersistentStore")
+      return false
+    }
+    
+    guard let storedModelVersionIdentifiers = currentPersistentStoreMetadata["NSStoreModelVersionIdentifiers"] as? [String] else {
+      PubNub.log.error("Cannot read versionIdentifiers from the currently stored NSManagedObjectModel")
+      return false
+    }
+    
+    let currentlyStoredModelVersion = Int(storedModelVersionIdentifiers.first ?? String()) ?? 0
+    let sortedModelVersions = sortedModelVersionFiles()
+    
+    guard let persistentStoreModel = sortedModelVersions.first(where: { $0.integerValue == currentlyStoredModelVersion }) else {
+      PubNub.log.error("The expected NSManagedObjectModel with version set to \(currentlyStoredModelVersion) could not be found")
+      return false
+    }
+    
+    var currentlyProcessedModel = persistentStoreModel
+    
+    for modelVersion in sortedModelVersions where modelVersion.integerValue > currentlyStoredModelVersion {
+      
+      // Gets metadata in each loop because the previous migration changed them
+      guard let storeMetadata = try? NSPersistentStoreCoordinator.metadataForPersistentStore(
         ofType: NSSQLiteStoreType,
         at: persistentStoreLocation
-      )
+      ) else {
+        PubNub.log.error("Cannot get NSPersistentStore metadata")
+        return false
+      }
+      
       if !modelVersion.isConfiguration(
         withName: nil,
         compatibleWithStoreMetadata: storeMetadata
       ) {
-        try autoreleasepool {
-          try performMigration(
-            from: rootModel,
-            to: modelVersion
-          )
+        do {
+          try autoreleasepool {
+            try performMigration(
+              from: currentlyProcessedModel,
+              to: modelVersion
+            )
+            currentlyProcessedModel = modelVersion
+          }
+        } catch {
+          PubNub.log.error("Migration failed due to error: \(error)")
+          return false
         }
       }
     }
+    
+    return true
+  }
+  
+  private func sortedModelVersionFiles() -> [NSManagedObjectModel] {
+    
+    let allVersionFiles = modelBundle.paths(
+      forResourcesOfType: "mom",
+      inDirectory: modelURL.lastPathComponent
+    )
+    
+    let sortedModels = allVersionFiles.compactMap() {
+      NSManagedObjectModel(contentsOf: URL(fileURLWithPath: $0))
+    }.sorted() {
+      $0.integerValue < $1.integerValue
+    }
+    
+    return sortedModels
   }
   
   private func performMigration(
     from sourceModel: NSManagedObjectModel,
     to destinationModel: NSManagedObjectModel
   ) throws {
+    
     let temporaryStoreLocation = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
     
     guard let mappingModel = try resolveMappingModel(between: sourceModel, and: destinationModel) else {
@@ -107,6 +166,7 @@ class DefaultCoreDataMigrationManager: CoreDataMigrationManager {
       destinationType: NSSQLiteStoreType,
       destinationOptions: [NSSQLitePragmasOption: ["journal_mode": "DELETE"]]
     )
+    
     try NSPersistentStoreCoordinator(managedObjectModel: destinationModel).replacePersistentStore(
       at: persistentStoreLocation,
       destinationOptions: nil,
@@ -114,6 +174,7 @@ class DefaultCoreDataMigrationManager: CoreDataMigrationManager {
       sourceOptions: nil,
       ofType: NSSQLiteStoreType
     )
+    
     try FileManager.default.removeItem(
       at: temporaryStoreLocation
     )
@@ -123,16 +184,26 @@ class DefaultCoreDataMigrationManager: CoreDataMigrationManager {
     between sourceModel: NSManagedObjectModel,
     and destinationModel: NSManagedObjectModel
   ) throws -> NSMappingModel? {
-    let mappingModel = try NSMappingModel.inferredMappingModel(forSourceModel: sourceModel, destinationModel: destinationModel)
-    // Pick the correct strategy by checking both model versions
-    PayloadAlignmentMigration.configure(mappingModel: mappingModel)
-    // Returns configured mapping model
+    
+    let mappingModel = try NSMappingModel.inferredMappingModel(
+      forSourceModel: sourceModel,
+      destinationModel: destinationModel
+    )
+    
+    // Picks the correct strategy by checking both model versions.
+    // Returns an inferred mapping model if the migration is not needed
+    if sourceModel.integerValue == 0 && destinationModel.integerValue == 1 {
+      PayloadAlignmentMigration.alter(mappingModel: mappingModel)
+    }
+    
     return mappingModel
   }
 }
 
 class PayloadAlignmentMigration {
-  static func configure(mappingModel: NSMappingModel) {
+  
+  static func alter(mappingModel: NSMappingModel) {
+    
     let entityMapping = mappingModel.entityMappings.first { $0.sourceEntityName == "PubNubManagedMessage" && $0.destinationEntityName == "PubNubManagedMessage" }!
     entityMapping.entityMigrationPolicyClassName = "PubNubChat.PayloadAlignmentMessageEntityMigration"
     entityMapping.mappingType = .customEntityMappingType
@@ -152,7 +223,9 @@ class PayloadAlignmentMigration {
 
 @objc(PayloadAlignmentMessageEntityMigration)
 class PayloadAlignmentMessageEntityMigration: NSEntityMigrationPolicy {
+  
   @objc func resolveTextProperty(_ content: Data) -> String {
+    
     let decodedContent = try? Constant.jsonDecoder.decode(AnyJSON.self, from: content)
     let currentTextValue = decodedContent?["text"]?.stringOptional
     

--- a/Sources/PubNubChat/Storage/CoreData/CoreDataProvider.swift
+++ b/Sources/PubNubChat/Storage/CoreData/CoreDataProvider.swift
@@ -88,13 +88,13 @@ public class CoreDataProvider: NSPersistentContainer {
     
     if location != StoreLocation.memory {
       if let migrationManager = migrationManager {
-        try migrationManager.migrateIfNeeded()
+        migrationManager.migrateIfNeeded()
       } else {
-        let momFiles = bundle.paths(forResourcesOfType: "mom", inDirectory: modelURL.lastPathComponent)
-        var models = momFiles.compactMap() { NSManagedObjectModel(contentsOf: URL(fileURLWithPath: $0)) }.sorted() { $0.versionID < $1.versionID }
-        let defaultMigrationManager = DefaultCoreDataMigrationManager(rootModel: models.removeFirst(), nextModelVersions: models, persistentStoreLocation: location.rawValue)
-        
-        try defaultMigrationManager.migrateIfNeeded()
+        DefaultCoreDataMigrationManager(
+          modelBundle: bundle,
+          modelURL: modelURL,
+          persistentStoreLocation: location.rawValue
+        ).migrateIfNeeded()
       }
     }
     

--- a/Sources/PubNubChat/Storage/CoreData/PubNubChatModel.xcdatamodeld/.xccurrentversion
+++ b/Sources/PubNubChat/Storage/CoreData/PubNubChatModel.xcdatamodeld/.xccurrentversion
@@ -3,6 +3,6 @@
 <plist version="1.0">
 <dict>
 	<key>_XCCurrentVersionName</key>
-	<string>PubNubChatModel-V2.xcdatamodel</string>
+	<string>PubNubChatModel-V3.xcdatamodel</string>
 </dict>
 </plist>

--- a/Sources/PubNubChat/Storage/CoreData/PubNubChatModel.xcdatamodeld/PubNubChatModel-V3.xcdatamodel/contents
+++ b/Sources/PubNubChat/Storage/CoreData/PubNubChatModel.xcdatamodeld/PubNubChatModel-V3.xcdatamodel/contents
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="1">
+<model type="com.apple.IDECoreDataModeler.DataModel" documentVersion="1.0" lastSavedToolsVersion="20086" systemVersion="21D62" minimumToolsVersion="Automatic" sourceLanguage="Swift" userDefinedModelVersionIdentifier="2">
     <entity name="PubNubManagedChannel" representedClassName="PubNubManagedChannel" syncable="YES">
         <attribute name="avatarURL" optional="YES" attributeType="URI"/>
         <attribute name="custom" optional="YES" attributeType="Binary"/>
@@ -10,7 +10,8 @@
         <attribute name="memberCount" optional="YES" attributeType="Integer 64" derived="YES" derivationExpression="members.@count" usesScalarValueType="YES"/>
         <attribute name="name" optional="YES" attributeType="String"/>
         <attribute name="presentMemberCount" optional="YES" transient="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
-        <attribute name="type" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String" defaultValueString="default"/>
         <relationship name="members" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMember" inverseName="channel" inverseEntity="PubNubManagedMember"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMessage" inverseName="channel" inverseEntity="PubNubManagedMessage"/>
         <fetchIndex name="byId">
@@ -25,9 +26,12 @@
     <entity name="PubNubManagedMember" representedClassName="PubNubManagedMember" syncable="YES">
         <attribute name="channelId" optional="YES" attributeType="String" derived="YES" derivationExpression="channel.id"/>
         <attribute name="custom" optional="YES" attributeType="Binary"/>
+        <attribute name="eTag" optional="YES" attributeType="String"/>
         <attribute name="id" attributeType="String"/>
         <attribute name="isPresent" attributeType="Boolean" defaultValueString="NO" usesScalarValueType="YES"/>
+        <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="presenceState" optional="YES" attributeType="Binary"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
         <attribute name="userId" optional="YES" attributeType="String" derived="YES" derivationExpression="user.id"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedChannel" inverseName="members" inverseEntity="PubNubManagedChannel"/>
         <relationship name="user" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedUser" inverseName="memberships" inverseEntity="PubNubManagedUser"/>
@@ -54,10 +58,31 @@
         <attribute name="pubnubUserId" optional="YES" attributeType="String" derived="YES" derivationExpression="author.id"/>
         <attribute name="text" attributeType="String"/>
         <attribute name="timetoken" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <relationship name="actions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMessageAction" inverseName="parent" inverseEntity="PubNubManagedMessageAction"/>
         <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedUser" inverseName="messages" inverseEntity="PubNubManagedUser"/>
         <relationship name="channel" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedChannel" inverseName="messages" inverseEntity="PubNubManagedChannel"/>
         <fetchIndex name="byChannelId">
             <fetchIndexElement property="pubnubChannelId" type="Binary" order="ascending"/>
+        </fetchIndex>
+        <uniquenessConstraints>
+            <uniquenessConstraint>
+                <constraint value="id"/>
+            </uniquenessConstraint>
+        </uniquenessConstraints>
+    </entity>
+    <entity name="PubNubManagedMessageAction" representedClassName="PubNubManagedMessageAction" syncable="YES">
+        <attribute name="id" optional="YES" attributeType="String"/>
+        <attribute name="published" optional="YES" attributeType="Integer 64" defaultValueString="0" usesScalarValueType="YES"/>
+        <attribute name="pubnubChannelId" optional="YES" attributeType="String"/>
+        <attribute name="pubnubParentId" optional="YES" attributeType="String" derived="YES" derivationExpression="parent.id"/>
+        <attribute name="pubnubParentTimetoken" optional="YES" attributeType="Integer 64" derived="YES" derivationExpression="parent.timetoken" usesScalarValueType="YES"/>
+        <attribute name="pubnubUserId" optional="YES" attributeType="String" derived="YES" derivationExpression="author.id"/>
+        <attribute name="sourceType" optional="YES" attributeType="String"/>
+        <attribute name="value" optional="YES" attributeType="String"/>
+        <relationship name="author" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedUser" inverseName="actions" inverseEntity="PubNubManagedUser"/>
+        <relationship name="parent" optional="YES" maxCount="1" deletionRule="Nullify" destinationEntity="PubNubManagedMessage" inverseName="actions" inverseEntity="PubNubManagedMessage"/>
+        <fetchIndex name="byMessageId">
+            <fetchIndexElement property="pubnubParentTimetoken" type="Binary" order="ascending"/>
         </fetchIndex>
         <uniquenessConstraints>
             <uniquenessConstraint>
@@ -74,7 +99,9 @@
         <attribute name="id" attributeType="String"/>
         <attribute name="lastUpdated" optional="YES" attributeType="Date" usesScalarValueType="NO"/>
         <attribute name="name" optional="YES" attributeType="String"/>
-        <attribute name="occupation" optional="YES" attributeType="String"/>
+        <attribute name="status" optional="YES" attributeType="String"/>
+        <attribute name="type" attributeType="String" defaultValueString="default"/>
+        <relationship name="actions" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMessageAction" inverseName="author" inverseEntity="PubNubManagedMessageAction"/>
         <relationship name="memberships" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMember" inverseName="user" inverseEntity="PubNubManagedMember"/>
         <relationship name="messages" optional="YES" toMany="YES" deletionRule="Nullify" destinationEntity="PubNubManagedMessage" inverseName="author" inverseEntity="PubNubManagedMessage"/>
         <fetchIndex name="byId">
@@ -90,6 +117,7 @@
         <element name="PubNubManagedChannel" positionX="-78.437255859375" positionY="268.0662231445312" width="128" height="209"/>
         <element name="PubNubManagedMember" positionX="160" positionY="192" width="128" height="149"/>
         <element name="PubNubManagedMessage" positionX="54" positionY="441" width="128" height="194"/>
-        <element name="PubNubManagedUser" positionX="-76.082275390625" positionY="465.6267700195312" width="128" height="194"/>
+        <element name="PubNubManagedMessageAction" positionX="45" positionY="351" width="128" height="29"/>
+        <element name="PubNubManagedUser" positionX="-76.082275390625" positionY="465.6267700195312" width="128" height="224"/>
     </elements>
 </model>


### PR DESCRIPTION
* Made the migration manager working with more than one model version
* New model version for VSP changes (`PubNubChatModel-V3`)
* Fixed unit tests