### PR TITLE
Change message reactions to disabled (by default)

### DIFF
--- a/Sources/PubNubChatComponents/Theming/MessageListComponentTheme.swift
+++ b/Sources/PubNubChatComponents/Theming/MessageListComponentTheme.swift
@@ -136,7 +136,7 @@ extension MessageListComponentTheme {
         bounceOffset: 0.25,
         fades: true
       ),
-      enableReactions: true
+      enableReactions: false
     )
   }
 }


### PR DESCRIPTION
Changed the `enableReactions` to `false` as we agreed in the team that message reactions should be disabled by default.