### PR TITLE
Added generic type for the content key inside ChatMessage.MessagePayload

### DIFF
--- a/Sources/PubNubChat/Helpers/CustomJSONData.swift
+++ b/Sources/PubNubChat/Helpers/CustomJSONData.swift
@@ -37,7 +37,8 @@ public struct VoidCustomData: Codable, Hashable,
   UserCustomData,
   ChannelCustomData,
   MemberCustomData,
-  MessageCustomData
+  MessageCustomData,
+  MessageContentData
 {
   public init() {}
   public init(flatJSON: [String: JSONCodableScalar]) { }
@@ -48,12 +49,14 @@ public protocol UserCustomData: CustomFlatJSONData {}
 public protocol ChannelCustomData: CustomFlatJSONData {}
 public protocol MemberCustomData: CustomFlatJSONData {}
 public protocol MessageCustomData: CustomJSONData {}
+public protocol MessageContentData: CustomJSONData {}
 
 public protocol ChatCustomData {
   associatedtype User: UserCustomData = VoidCustomData
   associatedtype Channel: ChannelCustomData = VoidCustomData
   associatedtype Member: MemberCustomData = VoidCustomData
   associatedtype Message: MessageCustomData = VoidCustomData
+  associatedtype MessageContent: MessageContentData = VoidCustomData
 }
 
 public protocol Defaultable {

--- a/Sources/PubNubChat/PubNub/Models/ChatMessage.swift
+++ b/Sources/PubNubChat/PubNub/Models/ChatMessage.swift
@@ -39,7 +39,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
     public var id: String
     public var text: String
     public var contentType: String?
-    public var content: JSONCodable?
+    public var content: Custom.MessageContent
     public var custom: Custom.Message
     public var createdAt: Date
 
@@ -56,7 +56,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
       id: String = UUID().uuidString,
       text: String = String(),
       contentType: String? = nil,
-      content: JSONCodable? = nil,
+      content: Custom.MessageContent = Custom.MessageContent(),
       custom: Custom.Message = Custom.Message(),
       createdAt: Date = Date()
     ) {
@@ -74,7 +74,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
       id = try container.decode(String.self, forKey: .id)
       text = try container.decode(String.self, forKey: .text)
       contentType = try container.decodeIfPresent(String.self, forKey: .contentType)
-      content = try container.decodeIfPresent(AnyJSON.self, forKey: .content)
+      content = try container.decodeIfPresent(Custom.MessageContent.self, forKey: .content) ?? Custom.MessageContent()
       custom = try container.decodeIfPresent(Custom.Message.self, forKey: .custom) ?? Custom.Message()
       createdAt = try container.decode(Date.self, forKey: .createdAt)
     }
@@ -100,7 +100,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
       try container.encode(id, forKey: .id)
       try container.encode(text, forKey: .text)
       try container.encodeIfPresent(contentType, forKey: .contentType)
-      try container.encodeIfPresent(content?.codableValue, forKey: .content)
+      try container.encodeIfPresent(content.codableValue, forKey: .content)
       try container.encodeIfPresent(custom, forKey: .custom)
       try container.encode(createdAt, forKey: .createdAt)
     }
@@ -112,7 +112,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
       return lhs.id == rhs.id &&
         lhs.text == rhs.text &&
         lhs.contentType == rhs.contentType &&
-        lhs.content?.codableValue == rhs.codableValue &&
+        lhs.content.codableValue == rhs.codableValue &&
         lhs.custom == rhs.custom &&
         lhs.createdAt == rhs.createdAt
     }
@@ -121,7 +121,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
       hasher.combine(id)
       hasher.combine(text)
       hasher.combine(contentType)
-      hasher.combine(content?.codableValue)
+      hasher.combine(content.codableValue)
       hasher.combine(custom)
       hasher.combine(createdAt)
     }
@@ -171,7 +171,7 @@ public struct ChatMessage<Custom: ChatCustomData>: Identifiable, Hashable, Codab
     dateCreated: Date = Date(),
     text: String,
     contentType: String? = nil,
-    content: JSONCodable? = nil,
+    content: Custom.MessageContent = Custom.MessageContent(),
     custom: Custom.Message = Custom.Message(),
     pubnubUserId: String,
     user: ChatUser<Custom.User>? = nil,

--- a/Sources/PubNubChat/Storage/CoreData/PubNubManagedMessage.swift
+++ b/Sources/PubNubChat/Storage/CoreData/PubNubManagedMessage.swift
@@ -84,12 +84,12 @@ extension PubNubManagedMessage: ManagedMessageEntity {
   
   public func convert<Custom: ChatCustomData>() throws -> ChatMessage<Custom> {
 
-    return ChatMessage(
+    return ChatMessage<Custom>(
       id: self.id,
       timetoken: self.timetoken,
       dateCreated: self.dateCreated,
       text: self.text,
-      content: try Constant.jsonDecoder.decode(AnyJSON.self, from: self.content),
+      content: try Constant.jsonDecoder.decode(Custom.MessageContent.self, from: self.content),
       custom: (try? Constant.jsonDecoder.decode(Custom.Message.self, from: custom)) ?? Custom.Message(),
       pubnubUserId: self.author.pubnubUserID,
       user: self.author.convert(),


### PR DESCRIPTION
I'm checking if it's worth to provide another generic parameter for `ChatMessage` without introducing breaking changes. Right now, the `content` property is `JSONCodable?` so you have to cast a value that this property holds to another type. This isn't convenient for our users, therefore a new improvement has been proposed. I realize that naming in `ChatMessage.swift` could be improved because now it's duplicated in some places. Anyway, ignore it for now and please take a look at the scope of changes (it's still a draft PR). There are 3 consequences:

- `MessageCustomData` now contains two associated types (`Content` and `Custom`) that have to be aliased if you want to provide a different type than `VoidCustomData` (which is set by default) for any of them
- `JSONCodable` as a type available before meant you can provide almost anything at any time when sending a new message. Now it's more constrained because of generics. You have to always provide the type you specified for `Content` or `Custom`
- Further documentation changes

Sample usage in any application that consumes Chat Components:

```
import PubNub
import PubNubChat

enum MyAppCustomData: ChatCustomData {
  typealias Message = AppMessageCustomData
}

enum AppMessageCustomData: MessageCustomData {
  typealias Content = ContentSample
  typealias Custom = CustomSample
}

struct ContentSample: MessageCustomDataContentKey {  
  let a: Int
  let b: Int
  
  init() {
    a = 11
    b = 22
  }
}

struct CustomSample: MessageCustomDataCustomKey {  
  let x: String
  let y: String
  
  init() {
    x = "Lorem"
    y = "Ipsum"
  }
}

let provider = ChatProvider<MyAppCustomData, PubNubManagedChatEntities>(pubnubProvider: PubNub(configuration: pubnubConfiguration))

// Getting messages
provider.dataProvider.syncRemoteMessages(MessageHistoryRequest(channels: ["my-channel"]), completion: { result in
  switch result {
  case .success((let messagesByChannelId, let next)):
    messagesByChannelId["my-channel"]?.forEach() {
      print($0.content.content) // Now you can access content like ContentSample instead of JSONCodable as it was before
      print($0.content.custom)
    }
  case .failure(let error):
    debugPrint(error)
  }
})

// Sending a new message
let payload = ChatMessage<MyAppCustomData>.MessagePayload(
  id: "123456",
  text: "Hey hey 2!",
  contentType: "custom",
  content: ContentSample(), // It's always required to pass ContentSample as a type (since you specified this in AppMessageCustomData above)
  custom: CustomSample(),
   createdAt: Date()
)
let newMessage = ChatMessage<MyAppCustomData>(
  content: payload, 
  pubnubUserId: "JG",
  pubnubChannelId: "my-channel"
)
```
